### PR TITLE
Improve block rendering performance

### DIFF
--- a/code/bigstitcher-qc/src/main/java/org/aind/bigstitcher/qc/CompositeUtils.java
+++ b/code/bigstitcher-qc/src/main/java/org/aind/bigstitcher/qc/CompositeUtils.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.stream.IntStream;
 import mpicbg.spim.data.generic.sequence.BasicViewDescription;
 import mpicbg.spim.data.sequence.ViewId;
 import mpicbg.spim.data.sequence.ViewSetup;
@@ -85,6 +84,7 @@ final class CompositeUtils {
 
         final List<RandomAccessibleInterval<FloatType>> transformedSources = new ArrayList<>(overlapping.size());
         final List<Integer> sourceIds = new ArrayList<>(overlapping.size());
+        final List<long[]> sourceBounds = new ArrayList<>(overlapping.size()); // [minX,minY,minZ,maxX,maxY,maxZ] in zero-min overlay coords
         final ColorMode effectiveMode = colorMode == null ? ColorMode.ILLUMINATION : colorMode;
 
         for (final ViewId vid : overlapping) {
@@ -108,6 +108,9 @@ final class CompositeUtils {
 
             transformed = Views.zeroMin(transformed);
             transformedSources.add(transformed);
+
+            // Compute this source's bounds within the overlay (zero-min) coordinates.
+            sourceBounds.add(Utils.computeSourceBounds(input, model, cropBB));
 
             final BasicViewDescription<ViewSetup> vd = vds.get(vid);
             final int sourceId = effectiveMode == ColorMode.ILLUMINATION
@@ -137,7 +140,8 @@ final class CompositeUtils {
         final long[] cropMin = new long[3];
         cropBB.min(cropMin);
 
-        return new CompositeBlockRenderer(outInterval, transformedSources, palette, colorIndexForSource, cropMin, displayMax);
+        final long[][] boundsArray = sourceBounds.toArray(new long[0][]);
+        return new CompositeBlockRenderer(outInterval, transformedSources, palette, colorIndexForSource, cropMin, displayMax, boundsArray);
     }
 
     static Path exportCompositeAsOmeZarr(
@@ -211,6 +215,7 @@ final class CompositeUtils {
         private final long[] spatialDims;
         private final double[] worldMin3d;
         private final float displayMax;
+        private final long[][] sourceBounds; // [minX,minY,minZ,maxX,maxY,maxZ] per source in zero-min overlay coords
 
         CompositeBlockRenderer(
                 final Interval interval,
@@ -218,7 +223,8 @@ final class CompositeUtils {
                 final int[] palette,
                 final int[] colorIndexForSource,
                 final long[] cropMin,
-                final float displayMax
+                final float displayMax,
+                final long[][] sourceBounds
         ) {
             this.sources = new ArrayList<>(sources);
             this.palette = palette;
@@ -231,6 +237,7 @@ final class CompositeUtils {
                     cropMin != null && cropMin.length > 2 ? cropMin[2] : 0.0
             };
             this.displayMax = displayMax;
+            this.sourceBounds = sourceBounds;
         }
 
         @Override
@@ -262,21 +269,44 @@ final class CompositeUtils {
             final int[] colorIndex = this.colorIndexForSource;
             final float localDisplayMax = this.displayMax;
 
-            IntStream.range(0, sizeZ).parallel().forEach(localZ -> {
-                final long globalZ = blockMin[2] + localZ;
-                final long[] pos = new long[] { 0L, 0L, globalZ };
-                final ArrayList<RandomAccess<FloatType>> ras = new ArrayList<>(sourceCount);
-                for (int s = 0; s < sourceCount; s++)
-                    ras.add(localSources.get(s).randomAccess());
+            // Determine active sources for this block by intersecting per-source bounds with the block bounds.
+            final List<Integer> activeSources = Utils.collectActiveSourcesForBlock(
+                    blockMin,
+                    sizeX,
+                    sizeY,
+                    sizeZ,
+                    sourceBounds,
+                    sourceCount
+            );
 
-                for (int y = 0; y < sizeY; y++) {
-                    pos[1] = blockMin[1] + y;
-                    final int rowOffset = (localZ * sizeY + y) * sizeX;
-                    for (int x = 0; x < sizeX; x++) {
-                        pos[0] = blockMin[0] + x;
+            if (activeSources.isEmpty())
+                return;
+
+            final int activeCountFinal = activeSources.size();
+            // Convert to primitive indices once to avoid autoboxing in the inner loops.
+            final int[] activeIdx = new int[activeCountFinal];
+            for (int i = 0; i < activeCountFinal; i++)
+                activeIdx[i] = activeSources.get(i);
+
+            final ArrayList<RandomAccess<FloatType>> ras = new ArrayList<>(activeCountFinal);
+            for (int i = 0; i < activeCountFinal; i++)
+                ras.add(localSources.get(activeIdx[i]).randomAccess());
+
+            final long[] pos = new long[] { 0L, 0L, 0L };
+
+            for (int localZ = 0; localZ < sizeZ; localZ++) {
+                pos[2] = blockMin[2] + localZ;
+                final int sliceOffset = localZ * sizeY;
+
+                for (int localY = 0; localY < sizeY; localY++) {
+                    pos[1] = blockMin[1] + localY;
+                    final int rowOffset = (sliceOffset + localY) * sizeX;
+
+                    for (int localX = 0; localX < sizeX; localX++) {
+                        pos[0] = blockMin[0] + localX;
                         int argb = 0;
-                        for (int s = 0; s < sourceCount; s++) {
-                            final RandomAccess<FloatType> ra = ras.get(s);
+                        for (int i = 0; i < activeCountFinal; i++) {
+                            final RandomAccess<FloatType> ra = ras.get(i);
                             ra.setPosition(pos);
                             final float val = ra.get().getRealFloat();
                             if (val <= 0)
@@ -284,20 +314,20 @@ final class CompositeUtils {
                             final int level = clampTo8bit((val / localDisplayMax) * 255f);
                             if (level == 0)
                                 continue;
-                            final int srcColor = tint(paletteLocal[colorIndex[s]], level);
+                            final int srcColor = tint(paletteLocal[colorIndex[activeIdx[i]]], level);
                             argb = maxBlend(argb, srcColor);
                         }
 
                         if (argb == 0)
                             continue;
 
-                        final int baseIndex = rowOffset + x;
+                        final int baseIndex = rowOffset + localX;
                         data[channelOffsets[0] + baseIndex] = (byte) ((argb >> 16) & 0xff);
                         data[channelOffsets[1] + baseIndex] = (byte) ((argb >> 8) & 0xff);
                         data[channelOffsets[2] + baseIndex] = (byte) (argb & 0xff);
                     }
                 }
-            });
+            }
         }
     }
 

--- a/code/bigstitcher-qc/src/main/java/org/aind/bigstitcher/qc/Utils.java
+++ b/code/bigstitcher-qc/src/main/java/org/aind/bigstitcher/qc/Utils.java
@@ -20,8 +20,10 @@ import mpicbg.spim.data.sequence.ViewSetup;
 import net.imglib2.Dimensions;
 import net.imglib2.FinalInterval;
 import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.util.Intervals;
+import net.imglib2.type.numeric.real.FloatType;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
 
 final class Utils {
@@ -97,6 +99,73 @@ final class Utils {
                     // ignore if cache cannot be cleared explicitly
                 }
             }
+        }
+    }
+
+    static List<Integer> collectActiveSourcesForBlock(
+            final long[] blockMin,
+            final int sizeX,
+            final int sizeY,
+            final int sizeZ,
+            final long[][] sourceBounds,
+            final int sourceCount
+    ) {
+        final long bx0 = blockMin[0];
+        final long by0 = blockMin[1];
+        final long bz0 = blockMin[2];
+        final long bx1 = bx0 + sizeX - 1;
+        final long by1 = by0 + sizeY - 1;
+        final long bz1 = bz0 + sizeZ - 1;
+
+        final List<Integer> active = new ArrayList<>();
+        for (int s = 0; s < sourceCount; s++) {
+            final long[] bounds = sourceBounds != null && s < sourceBounds.length ? sourceBounds[s] : null;
+            if (bounds == null)
+                continue;
+            if (bounds[0] > bounds[3] || bounds[1] > bounds[4] || bounds[2] > bounds[5])
+                continue;
+            final boolean intersects = !(bounds[0] > bx1 || bounds[3] < bx0 ||
+                                         bounds[1] > by1 || bounds[4] < by0 ||
+                                         bounds[2] > bz1 || bounds[5] < bz0);
+            if (intersects)
+                active.add(s);
+        }
+        return active;
+    }
+
+    /* Determine the bounding box of the source in the zero-min coordinates */
+    static long[] computeSourceBounds(
+            final RandomAccessibleInterval<FloatType> input,
+            final AffineTransform3D model,
+            final Interval cropBB
+    ) {
+        try {
+            final FinalInterval inputInterval = new FinalInterval(input);
+            final Interval worldBounds = Intervals.largestContainedInterval(model.estimateBounds(inputInterval));
+            final Interval clipped = Intervals.intersect(worldBounds, cropBB);
+            final long[] bounds = new long[6];
+            if (Intervals.isEmpty(clipped)) {
+                bounds[0] = 1;
+                bounds[1] = 1;
+                bounds[2] = 1;
+                bounds[3] = 0;
+                bounds[4] = 0;
+                bounds[5] = 0;
+            } else {
+                final long[] minWorld = new long[3];
+                final long[] maxWorld = new long[3];
+                clipped.min(minWorld);
+                clipped.max(maxWorld);
+                final long[] cropMinArr = new long[3];
+                cropBB.min(cropMinArr);
+                for (int d = 0; d < 3; d++) {
+                    bounds[d] = Math.max(0, minWorld[d] - cropMinArr[d]);
+                    bounds[3 + d] = Math.max(-1, maxWorld[d] - cropMinArr[d]);
+                }
+            }
+            return bounds;
+        } catch (final Exception e) {
+            return new long[] { 1, 1, 1, 0, 0, 0 };
         }
     }
 }


### PR DESCRIPTION
- Only loop over views that actually touch current block, otherwise we are checking 400 sources at each voxel in the main render loop which is very slow