### PR TITLE
Feat: support direct S3 writes

### DIFF
--- a/code/bigstitcher-qc/src/main/java/org/aind/bigstitcher/qc/CompositeUtils.java
+++ b/code/bigstitcher-qc/src/main/java/org/aind/bigstitcher/qc/CompositeUtils.java
@@ -1,6 +1,7 @@
 package org.aind.bigstitcher.qc;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -144,24 +145,36 @@ final class CompositeUtils {
         return new CompositeBlockRenderer(outInterval, transformedSources, palette, colorIndexForSource, cropMin, displayMax, boundsArray);
     }
 
-    static Path exportCompositeAsOmeZarr(
+    static URI exportCompositeAsOmeZarr(
             final CompositeBlockRenderer overlay,
-            final Path outputRoot,
-            final String relativeName,
+            final String containerLocation,
+            final String datasetLabel,
             final Integer userDefinedBlockSize,
             final int maxDownsamplingLevels,
             final String unit
     ) throws IOException {
-        if (outputRoot == null)
-            throw new IllegalStateException("OME-Zarr output root is not configured");
+        if (containerLocation == null || containerLocation.isEmpty())
+            throw new IllegalStateException("OME-Zarr output location is not configured");
 
-        final Path outputFolder = outputRoot.resolve(relativeName).normalize();
-        final Path containerPath = outputFolder.getParent() == null
-                ? Paths.get(outputFolder.toString() + ".ome.zarr")
-                : outputFolder.getParent().resolve(outputFolder.getFileName().toString() + ".ome.zarr");
+        final URI containerUri = URITools.toURI(containerLocation);
+        final boolean isLocal = URITools.isFile(containerUri);
+        final Path localContainerPath = isLocal ? Paths.get(URITools.fromURI(containerUri)).toAbsolutePath().normalize() : null;
 
-        Files.createDirectories(containerPath.getParent());
-        Utils.deleteRecursivelyIfExists(containerPath);
+        if (isLocal && localContainerPath != null) {
+            final Path parent = localContainerPath.getParent();
+            if (parent != null)
+                Files.createDirectories(parent);
+            Utils.deleteRecursivelyIfExists(localContainerPath);
+        }
+
+        final String datasetDisplayName;
+        if (datasetLabel != null && !datasetLabel.isEmpty()) {
+            datasetDisplayName = Utils.lastPathSegmentOrDefault(datasetLabel, datasetLabel);
+        } else if (isLocal && localContainerPath != null) {
+            datasetDisplayName = localContainerPath.getFileName().toString();
+        } else {
+            datasetDisplayName = Utils.lastPathSegmentOrDefault(containerUri.getPath(), "dataset");
+        }
 
         final long[] spatialDims = overlay.spatialDimensions();
         final long[] dims5d = new long[] { spatialDims[0], spatialDims[1], spatialDims[2], 3, 1 };
@@ -173,7 +186,7 @@ final class CompositeUtils {
         try {
             try (final N5Writer writer = URITools.instantiateN5Writer(
                     StorageFormat.ZARR,
-                    URITools.toURI(containerPath.toString()))) {
+                    containerUri)) {
 
                 final MultiResolutionLevelInfo[] pyramid = N5ApiTools.setupMultiResolutionPyramid(
                         writer,
@@ -190,7 +203,7 @@ final class CompositeUtils {
                 ZarrUtils.writeOmeNgffMetadata(
                         writer,
                         pyramid,
-                        containerPath.getFileName().toString(),
+                        datasetDisplayName,
                         overlay.worldMin3d(),
                         unit
                 );
@@ -199,7 +212,7 @@ final class CompositeUtils {
             ZarrUtils.shutdownExecutor(executor);
         }
 
-        return containerPath;
+        return containerUri;
     }
 
     interface BlockRenderer {

--- a/code/bigstitcher-qc/src/main/java/org/aind/bigstitcher/qc/FuseCompositeOverlaps.java
+++ b/code/bigstitcher-qc/src/main/java/org/aind/bigstitcher/qc/FuseCompositeOverlaps.java
@@ -1,6 +1,7 @@
 package org.aind.bigstitcher.qc;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,7 +44,7 @@ public class FuseCompositeOverlaps {
     private static final double DEFAULT_ANISOTROPY = 1.0;
     private static final double DEFAULT_DOWNSAMPLING = 8.0;
     private static final int DEFAULT_MAX_DOWNSAMPLING_LEVELS = 7;
-    private static Path omeZarrRoot;
+    private static String omeZarrRoot;
     private static Integer userDefinedBlockSize;
     private static final String UNIT_PIXEL = "micrometer";
     private static int maxDownsamplingLevels = DEFAULT_MAX_DOWNSAMPLING_LEVELS;
@@ -57,8 +58,8 @@ public class FuseCompositeOverlaps {
         @Parameters(index = "0", paramLabel = "XML", description = "Path to the BigStitcher XML dataset.")
         Path xmlPath;
 
-        @Parameters(index = "1", paramLabel = "OUTPUT", description = "Root directory where OME-Zarr crops will be written.")
-        Path outputRoot;
+        @Parameters(index = "1", paramLabel = "OUTPUT", description = "Root directory or URI where OME-Zarr crops will be written.")
+        String outputRoot;
 
         @Option(names = "--block-size", paramLabel = "INT", description = "Override cubic block size in voxels.")
         Integer blockSizeOverride;
@@ -105,6 +106,9 @@ public class FuseCompositeOverlaps {
     }
 
     public static void main(String[] args) throws Exception {
+        // Preflight: propagate AWS region to N5 S3 writer if provided
+        Utils.configureS3RegionFromEnv();
+
         final CliOptions options = new CliOptions();
         final CommandLine commandLine = new CommandLine(options);
 
@@ -144,7 +148,7 @@ public class FuseCompositeOverlaps {
             return;
         }
 
-        omeZarrRoot = options.outputRoot.toAbsolutePath().normalize();
+        omeZarrRoot = Utils.normalizeOutputRoot(options.outputRoot);
         userDefinedBlockSize = options.blockSizeOverride;
         displayMax = (float) options.displayMax;
         maxDownsamplingLevels = options.maxDownsamplingLevels;
@@ -346,7 +350,7 @@ public class FuseCompositeOverlaps {
             final CompositeUtils.CompositeBlockRenderer overlay,
             final String name
     ) throws IOException {
-        final Path containerPath = CompositeUtils.exportCompositeAsOmeZarr(
+        final URI containerUri = CompositeUtils.exportCompositeAsOmeZarr(
                 overlay,
                 omeZarrRoot,
                 name,
@@ -355,6 +359,6 @@ public class FuseCompositeOverlaps {
                 UNIT_PIXEL
         );
 
-        System.out.println("Exported multiscale OME-Zarr crop to " + containerPath);
+        System.out.println("Exported multiscale OME-Zarr crop to " + containerUri);
     }
 }

--- a/code/bigstitcher-qc/src/main/java/org/aind/bigstitcher/qc/FuseCompositeVolume.java
+++ b/code/bigstitcher-qc/src/main/java/org/aind/bigstitcher/qc/FuseCompositeVolume.java
@@ -1,6 +1,7 @@
 package org.aind.bigstitcher.qc;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
@@ -37,7 +38,7 @@ public class FuseCompositeVolume {
     private static final int DEFAULT_INTERPOLATION = 1;
     private static final String UNIT_PIXEL = "micrometer";
 
-    private static Path omeZarrRoot;
+    private static String omeZarrRoot;
     private static Integer userDefinedBlockSize;
     private static int maxDownsamplingLevels = DEFAULT_MAX_DOWNSAMPLING_LEVELS;
     private static int interpolation = DEFAULT_INTERPOLATION;
@@ -51,8 +52,8 @@ public class FuseCompositeVolume {
         @Parameters(index = "0", paramLabel = "XML", description = "Path to the BigStitcher XML dataset.")
         Path xmlPath;
 
-        @Parameters(index = "1", paramLabel = "OUTPUT", description = "Root directory where the OME-Zarr volume will be written.")
-        Path outputRoot;
+        @Parameters(index = "1", paramLabel = "OUTPUT", description = "Root directory or URI where the OME-Zarr volume will be written.")
+        String outputRoot;
 
         @Option(names = "--block-size", paramLabel = "INT", description = "Override cubic block size in voxels.")
         Integer blockSizeOverride;
@@ -115,6 +116,9 @@ public class FuseCompositeVolume {
     }
 
     public static void main(final String[] args) throws Exception {
+        // Preflight: propagate AWS region to N5 S3 writer if provided
+        Utils.configureS3RegionFromEnv();
+
         final CliOptions options = new CliOptions();
         final CommandLine commandLine = new CommandLine(options);
 
@@ -163,7 +167,8 @@ public class FuseCompositeVolume {
             return;
         }
 
-        omeZarrRoot = options.outputRoot.toAbsolutePath().normalize();
+        omeZarrRoot = Utils.normalizeOutputRoot(options.outputRoot);
+        System.out.println("OME-Zarr output root: " + omeZarrRoot);
         userDefinedBlockSize = options.blockSizeOverride;
         displayMax = (float) options.displayMax;
         maxDownsamplingLevels = options.maxDownsamplingLevels;
@@ -263,7 +268,7 @@ public class FuseCompositeVolume {
             final CompositeUtils.CompositeBlockRenderer overlay,
             final String datasetName
     ) throws IOException {
-        final Path containerPath = CompositeUtils.exportCompositeAsOmeZarr(
+        final URI containerUri = CompositeUtils.exportCompositeAsOmeZarr(
                 overlay,
                 omeZarrRoot,
                 datasetName,
@@ -272,7 +277,7 @@ public class FuseCompositeVolume {
                 UNIT_PIXEL
         );
 
-        System.out.println("Exported multiscale OME-Zarr volume to " + containerPath);
+        System.out.println("Exported multiscale OME-Zarr volume to " + containerUri);
     }
 
 }

--- a/code/bigstitcher-qc/src/main/java/org/aind/bigstitcher/qc/Utils.java
+++ b/code/bigstitcher-qc/src/main/java/org/aind/bigstitcher/qc/Utils.java
@@ -5,8 +5,10 @@ import bdv.cache.CacheControl;
 import bdv.img.cache.VolatileGlobalCellCache;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -25,6 +27,7 @@ import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.util.Intervals;
 import net.imglib2.type.numeric.real.FloatType;
 import net.preibisch.mvrecon.fiji.spimdata.SpimData2;
+import util.URITools;
 
 final class Utils {
 
@@ -45,6 +48,42 @@ final class Utils {
             });
         } catch (UncheckedIOException e) {
             throw e.getCause();
+        }   
+    }
+
+    /**
+     * Return the last path segment after normalizing separators. If the input is
+     * null or cannot yield a non-empty segment, returns defaultValue.
+     * Examples:
+     * - "s3://bucket/foo/bar.ome.zarr" -> "bar.ome.zarr"
+     * - "/data/out/vol.ome.zarr/" -> "vol.ome.zarr"
+     * - "name-only" -> "name-only"
+     */
+    static String lastPathSegmentOrDefault(final String pathLike, final String defaultValue) {
+        if (pathLike == null)
+            return defaultValue;
+        String s = pathLike.replace('\\', '/');
+        if (s.isEmpty())
+            return defaultValue;
+        if (s.endsWith("/"))
+            s = s.substring(0, s.length() - 1);
+        final int idx = s.lastIndexOf('/');
+        final String segment = idx >= 0 ? s.substring(idx + 1) : s;
+        return (segment == null || segment.isEmpty()) ? defaultValue : segment;
+    }
+
+    /**
+     * Configure the S3 region for the N5 S3 writer from common environment variables.
+     * Looks up AWS_REGION first, then AWS_DEFAULT_REGION. If a value is present,
+     * assigns it to URITools.s3Region so N5Factory uses the correct region.
+     */
+    static void configureS3RegionFromEnv() {
+        try {
+            String r = System.getenv("AWS_REGION");
+            if (r == null || r.isEmpty()) r = System.getenv("AWS_DEFAULT_REGION");
+            if (r != null && !r.isEmpty()) URITools.s3Region = r;
+        } catch (Exception ignored) {
+            // ignore
         }
     }
 
@@ -168,4 +207,17 @@ final class Utils {
             return new long[] { 1, 1, 1, 0, 0, 0 };
         }
     }
+
+    static String normalizeOutputRoot(final String raw) {
+        if (raw == null || raw.isEmpty())
+            return raw;
+
+        final URI uri = URITools.toURI(raw);
+        if (URITools.isFile(uri)) {
+            final Path path = Paths.get(URITools.fromURI(uri)).toAbsolutePath().normalize();
+            return path.toString();
+        }
+        return uri.toString();
+    }
+
 }


### PR DESCRIPTION
This PR adds support to write ome-zarr outputs direct to S3.

* **Important hack:** due to hardcoded s3 client building logic in `multiview-reconstruction,` it is necessary to update the `URITools.s3Region` class attribute (which defaults to `null` and has no setter) from environment variables before calling any S3 operations, otherwise we get `AccessDenied` errors. See https://github.com/JaneliaSciComp/multiview-reconstruction/blob/b0c1b3adb9d0d1d5bb5cb74075aede2664add145/src/main/java/util/URITools.java#L281-L302 . A `Utils.configureS3RegionFromEnv` hook was added which updates this attribute from the `AWS_REGION` env var. 